### PR TITLE
 Update PHP encryptDecrypt example to use OpenSSL - other miscellaneous changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ A basic introduction to the TASS API's.
 
 * **Protocol**
 
-	The protocol is defined in the TASS API Setup in tass.web. This can be set to allow HTTP or HTTPS requests. It can also be set to restrict requests to HTTPS only.
+	The protocol is defined in the TASS API Setup in TASS.web. This can be set to allow HTTP or HTTPS requests. It can also be set to restrict requests to HTTPS only.
 
 * **Domain**
 
-	The domain of the tass.web server you wish to make the request to.
+	The domain of the TASS.web server you wish to make the request to.
 
 * **Method**
 
@@ -37,11 +37,11 @@ A basic introduction to the TASS API's.
 
 * **App Code**
 
-	The App Code as defined in the tass.web TASS API Setup.
+	The App Code as defined in the TASS.web TASS API Setup.
 
 * **Company Code**
 
-	The Company Code for which the TASS API App has been configured in tass.web.
+	The Company Code for which the TASS API App has been configured in TASS.web.
 
 * **Token**
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ A basic introduction to the TASS API's.
   * encryptDecrypt.cs - A basic C# Encrypt and Decrypt class example
   * POST.html - A HTML page with a form
   * GET.html - A HTML page with an anchor
-  * DELPHI POST Example Function - A Delphi Example ( @filebound )
-  * EncryptDecrypt.ps1 - PowerShell Encrypt and Decrypt ( @sam-fisher )
-  * encryptDecrypt.cfm - CFML Encrypt and Decrypt example ( @ajdyka )
-  * encryptDecrypt.py - Python Encrypt and Decrypt example ( @liamstevens )
-  * encryptDecrypt3.py - Python3 Encrypt and Decrypt example ( @liamstevens )
-  * encryptDecrypt.php - PHP Encrypt and Decrypt example ( @liamstevens, @jtc )
+  * DELPHI POST Example Function - A Delphi Example ([@filebound](https://github.com/filebound))
+  * EncryptDecrypt.ps1 - PowerShell Encrypt and Decrypt ([@sam-fisher](https://github.com/sam-fisher))
+  * encryptDecrypt.cfm - CFML Encrypt and Decrypt example ([@ajdyka](https://github.com/ajdyka))
+  * encryptDecrypt.py - Python Encrypt and Decrypt example ([@liamstevens](https://github.com/liamstevens))
+  * encryptDecrypt3.py - Python3 Encrypt and Decrypt example ([@liamstevens](https://github.com/liamstevens))
+  * encryptDecrypt.php - PHP Encrypt and Decrypt example ([@liamstevens](https://github.com/liamstevens), [@jtc](https://github.com/jtc))
  
 **Request URL Construction**
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A basic introduction to the TASS API's.
   * encryptDecrypt.cfm - CFML Encrypt and Decrypt example ( @ajdyka )
   * encryptDecrypt.py - Python Encrypt and Decrypt example ( @liamstevens )
   * encryptDecrypt3.py - Python3 Encrypt and Decrypt example ( @liamstevens )
-  * encryptDecrypt.php - PHP Encrypt and Decrypt example ( @liamstevens )
+  * encryptDecrypt.php - PHP Encrypt and Decrypt example ( @liamstevens, @jtc )
  
 **Request URL Construction**
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A basic introduction to the TASS API's.
 
 * **Protocol**
 
-	The protocol is defined in the TASS API Setup in TASS.web. This can be set to allow HTTP or HTTPS requests. It can also be set to restrict requests to HTTPS only.
+	The protocol is defined in the TASS API Setup in TASS.web. As of TASS v49, this is set to restrict requests to HTTPS only.
 
 * **Domain**
 

--- a/encryptDecrypt.php
+++ b/encryptDecrypt.php
@@ -1,66 +1,46 @@
 <?php
-/*Author: Liam Stevens (ICT Analyst, St Joseph's College Gregory Terrace)
-Created on: 21/8/2018
+// An example of encrypting and decrypting your Token and accessing the API using PHP; specifically the getStudentsDetails method.
 
-Based on a C# example by @ricardorusson and PS example by @sam-fisher:
-https://github.com/TheAlphaSchoolSystemPTYLTD/api-introduction/blob/master/encryptDecrypt.cs
-https://github.com/TheAlphaSchoolSystemPTYLTD/api-introduction/blob/master/EncryptDecrypt.ps1
-
-An example of encrypting and decrypting your Token and accessing the API using PHP; specifically the getStudentsDetails method.*/
-
-//Constants to use when generating API requests - change these as per your TASS API Gateway
+	// Constants to use when generating API requests - change these as per your TASS API Gateway
 	$tokenKey = 'x8FWQUedjyiUGlTf5appPQ==';
 	$appCode = 'DEMOAPP';
 	$companyCode = '10';
 	$apiVersion = '2';
-	$method = 'GetStudentsDetails';
-	$endPoint = 'http://api.tasscloud.com.au/tassweb/api/';
-	$parameters = "{\"currentstatus\":\"current\"}";
+	$method = 'getStudentsDetails';
+	$endPoint = 'https://api.tasscloud.com.au/tassweb/api/';
+	$parameters =  '{"currentstatus":"current"}';
 
-	function Decrypt($s){
-		global $tokenKey;
-
-		if ($s == "") { return $s; }
-		// Turn the cipherText into a ByteArray from Base64
-		try {
+	function Encrypt($tokenKey, $parameters) {
 		$decodedKey = base64_decode($tokenKey);
-		$s = mcrypt_decrypt(MCRYPT_RIJNDAEL_128, $decodedKey, $s, MCRYPT_MODE_ECB);
-		} catch(Exception $e) {
-		// There is a problem with the string, perhaps it has bad base64 padding
-		// Do Nothing
-		}
-		return $s;
-	}
-
-	function Encrypt($s){
-		global $tokenKey;
-
-		$decodedKey = base64_decode($tokenKey);
-		// Have to pad if it is too small
-		$block = mcrypt_get_block_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_ECB);
-		$pad = $block - (strlen($s) % $block);
-		$s .= str_repeat(chr($pad), $pad);
-		$encrypted = mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $decodedKey, $s, MCRYPT_MODE_ECB);
+		$encrypted = openssl_encrypt($parameters, 'aes-128-ecb', $decodedKey, OPENSSL_RAW_DATA);
 		$encoded = base64_encode($encrypted);
 		return $encoded;
 	}
 
+	function Decrypt($tokenKey, $s) {
+		$decodedKey = base64_decode($tokenKey);
+		$s = base64_decode($s);
+		$s = openssl_decrypt($s, 'aes-128-ecb', $decodedKey, OPENSSL_RAW_DATA);
+		return $s;
+	}
+
 	function getURLRequest($endPoint, $method, $appCode, $companyCode, $apiVersion, $parameters, $tokenKey) {
-		$encryptedkey = Encrypt($parameters);
-		$dict = array('method'=>$method, 'appcode'=>$appCode, 'company'=>$companyCode, 'v'=>$apiVersion, 'token'=>$encryptedkey);
-		$keys = array_keys($dict);
+		$encryptedToken = Encrypt($tokenKey, $parameters);
+		$dict = array('method' => $method, 'appcode' => $appCode, 'company' => $companyCode, 'v' => $apiVersion, 'token' => $encryptedToken);
 		$URLString = $endPoint . '?';
-		foreach($keys as $value) {
-			$URLString .= $value;
+		foreach($dict as $key => $value) {
+			$URLString .= $key;
 			$URLString .= '=';
-			$URLString .= urlencode($dict[$value]);
+			$URLString .= urlencode($value);
 			$URLString .= '&';
 		}
 		// Trim the last ampersand because it's not necessary
 		$URLString = substr($URLString, 0, -1);
-		#Echo for example purposes, remove this in production
-		echo $URLString;
 		return $URLString;
 	}
-
+	
+	echo 'Original:   ', $parameters, PHP_EOL;
+	echo 'Encrypted:  ', Encrypt($tokenKey, $parameters), PHP_EOL;
+	echo 'Decrypted:  ', Decrypt($tokenKey, Encrypt($tokenKey, $parameters)), PHP_EOL;
+	echo 'URL:        ', getURLRequest($endPoint, $method, $appCode, $companyCode, $apiVersion, $parameters, $tokenKey), PHP_EOL;
 ?>

--- a/encryptDecrypt.php
+++ b/encryptDecrypt.php
@@ -56,7 +56,7 @@ An example of encrypting and decrypting your Token and accessing the API using P
 			$URLString .= urlencode($dict[$value]);
 			$URLString .= '&';
 		}
-		#Trim the last ampersand because it's not necessary
+		// Trim the last ampersand because it's not necessary
 		$URLString = substr($URLString, 0, -1);
 		#Echo for example purposes, remove this in production
 		echo $URLString;


### PR DESCRIPTION
I've updated the PHP encryptDecrypt example to use OpenSSL instead of the deprecated Mcrypt, which fixes #7

While doing so, I've refactored the PHP code a bit, and also made some updates to the README file (see individual commits for details).

I've tried to split up the commits and allow TASS edit access to my branch in case you want to accept some but not all of the changes, but feel free to let me know if you'd like me to make any changes or split into separate pull requests 😃